### PR TITLE
Basic auth fixes and support for Kibi access control plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ export default function (kibana) {
       }).default();
     },
 
-    init: require('./init.js'),
+    init: require('./init.js')
 
   });
 };

--- a/init.js
+++ b/init.js
@@ -19,30 +19,42 @@
 
 import later from 'later';
 import _ from 'lodash';
-import mustache from 'mustache';
 import masterRoute from './server/routes/routes';
 import scheduler from './server/lib/scheduler';
 import helpers from './server/lib/helpers';
-import $window from 'jquery';
+import getSentinelClient from './server/lib/get_sentinel_client';
 
-module.exports = function (server, options) {
+const init = _.once((server) => {
+  var config = require('./server/lib/config');
 
-      var debug = false;
-      var config = require('./server/lib/config');
+  server.log(['status', 'info', 'KaaE'], 'KaaE Initializing');
+  server.kaaeStore = [];
 
-      var $ = require('jquery');
-      server.log(['status', 'info', 'KaaE'], 'KaaE Initializing');
-      server.kaaeStore = [];
-      masterRoute(server);
+  masterRoute(server);
 
-      // Create KaaE Indices, if required
-      helpers.createKaaeIndex(server,config);
-      helpers.createKaaeAlarmIndex(server,config);
+  // Create KaaE Indices, if required
+  helpers.createKaaeIndex(server,config);
+  helpers.createKaaeAlarmIndex(server,config);
 
-      /* Bird Watching and Duck Hunting */
-      var client = server.plugins.elasticsearch.client;
-      var sched = later.parse.recur().on(25,55).second();;
-      var t = later.setInterval(function(){ scheduler.doalert(server,client) }, sched);
-      /* run NOW, plus later */
-      scheduler.doalert(server,client);
+  /* Bird Watching and Duck Hunting */
+  const client = getSentinelClient(server);
+  var sched = later.parse.recur().on(25,55).second();
+  var t = later.setInterval(function(){ scheduler.doalert(server,client) }, sched);
+  /* run NOW, plus later */
+  scheduler.doalert(server,client);
+});
+
+export default function (server, options) {
+
+  let status = server.plugins.elasticsearch.status;
+  if (status && status.state === 'green') {
+      init(server);
+  } else {
+    status.on('change', () => {
+      if (server.plugins.elasticsearch.status.state === 'green') {
+        init(server);
+      }
+    });
+  }
+
 };

--- a/public/app.js
+++ b/public/app.js
@@ -210,19 +210,20 @@ uiModules
 
     });
 
-  $scope.deleteAlarm = function($index){
-     if (confirm('Delete is Forever!\n Are you sure?')) {
-	 return $http.get('../api/kaae/delete/alarm/'+$scope.elasticAlarms[$index]._index
-			  + '/'+$scope.elasticAlarms[$index]._type
-			  + '/'+$scope.elasticAlarms[$index]._id ).then(function (resp) {
-        	console.log('API ALARM DELETE:',resp.data);
-			 var reload = $timeout(function () {
-		  	      $scope.elasticAlarms.splice($index,1);
-		 	      $scope.notify.warning('KAAE Alarm log successfully deleted!');
-		 	 }, 500);
-         });
-      }
-  }
+  $scope.deleteAlarm = function ($index) {
+    if (confirm('Delete is Forever!\n Are you sure?')) {
+      return $http.get('../api/kaae/delete/alarm/' + $scope.elasticAlarms[$index]._index
+        + '/' + $scope.elasticAlarms[$index]._type
+        + '/' + $scope.elasticAlarms[$index]._id)
+      .then(
+        () => $timeout(function () {
+          $scope.elasticAlarms.splice($index, 1);
+          $scope.notify.warning('KAAE Alarm log successfully deleted!');
+        }),
+        $scope.notify.error
+      );
+    }
+  };
 
   $scope.deleteAlarmLocal = function($index){
 	 $scope.notify.warning('KAAE function not yet implemented!');
@@ -310,26 +311,20 @@ uiModules
 	  else { $scope.editor.getSession().setMode("ace/mode/text"); }
   }
 
-  $scope.watcherDelete = function($index){
-     if (confirm('Are you sure?')) {
-	 return $http.get('../api/kaae/delete/watcher/'+$scope.watchers[$index]._id).then(function (resp) {
-		if (resp.statusCode < 200 || resp.statusCode > 299) {
-			$scope.notify.error('Error Deleting Watcher! Check your syntax and try again!');
-    		}
-    		else {
-			 var reload = $timeout(function () {
-		              $route.reload();
-		 	      $scope.notify.warning('KAAE Watcher successfully deleted!');
-		 	 }, 1000);
-		}
-         });
-      }
-  }
-
-  $scope.watcherGet = function($index){
-	 return $http.get('../api/kaae/get/watcher/'+$scope.watchers[$index]._id).then(function (resp) {
-         });
-  }
+  $scope.watcherDelete = function ($index) {
+    if (confirm('Are you sure?')) {
+      return $http.get('../api/kaae/delete/watcher/' + $scope.watchers[$index]._id)
+      .then(
+        (resp) => {
+          $timeout(function () {
+            $route.reload();
+            $scope.notify.warning('KAAE Watcher successfully deleted!');
+          });
+        },
+        $scope.notify.error
+      );
+    }
+  };
 
   $scope.watcherSave = function($index){
     var watcher = $scope.editor ? JSON.parse($scope.editor.getValue()) : $scope.watchers[$index];

--- a/server/lib/actions.js
+++ b/server/lib/actions.js
@@ -21,12 +21,14 @@ import _ from 'lodash';
 import mustache from 'mustache';
 import config from './config';
 import fs from 'fs';
+import getSentinelClient from './get_sentinel_client';
 
 var debug = true;
 var hlimit = config.kaae.history ? config.kaae.history : 10;
 
 export default function (server, actions, payload) {
 
+    const client = getSentinelClient(server);
     /* Email Settings */
     if (config.settings.email.active) {
         var email = require("emailjs");
@@ -96,7 +98,6 @@ export default function (server, actions, payload) {
 
     /* ES Indexing Functions */
     var esHistory = function (type, message, loglevel, payload) {
-        var client = server.plugins.elasticsearch.client;
         if (!loglevel) {
             var loglevel = "INFO"
         }

--- a/server/lib/get_sentinel_client.js
+++ b/server/lib/get_sentinel_client.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the Elasticsearch client used to create indices, execute watches and store alarms.
+ */
+export default function (server) {
+  if (server.plugins.kibi_access_control) {
+    return server.plugins.kibi_access_control.getSentinelClient();
+  }
+  return server.plugins.elasticsearch.client;
+}

--- a/server/lib/helpers.js
+++ b/server/lib/helpers.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import getSentinelClient from './get_sentinel_client';
+
 var dynamicTemplates = [ {
   string_fields : {
     mapping : {
@@ -45,7 +47,7 @@ function createKaaeIndex(server,config) {
           return;
         }
 
-        var client = server.plugins.elasticsearch.client;
+        var client = getSentinelClient(server);
         client.indices.exists({
           index: config.es.default_index
         }, function (error, exists) {
@@ -108,7 +110,7 @@ function createKaaeAlarmIndex(server,config) {
           return;
         }
 
-        var client = server.plugins.elasticsearch.client;
+        var client = getSentinelClient(server);
         client.indices.exists({
           index: config.es.alarm_index
         }, function (error, exists) {

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -4,8 +4,6 @@ const config = require('../lib/config');
 
 export default function (server) {
 
-  let call = server.plugins.elasticsearch.callWithRequest;
-
   // Current Time
   server.route({
     path: '/api/kaae/example',
@@ -44,41 +42,35 @@ export default function (server) {
     handler: function (req, reply) {
       // Use selected timefilter when available
       if (server.kaaeInterval) {
-	var timeInterval = server.kaaeInterval;
+        var timeInterval = server.kaaeInterval;
       } else {
-	var timeInterval = {from: "now-15m", mode: "quick", to: "now"};
+        var timeInterval = {from: "now-15m", mode: "quick", to: "now"};
       }
-      var qrange = { gte: timeInterval.from, lt: timeInterval.to };
+      var qrange = {gte: timeInterval.from, lt: timeInterval.to};
 
       const boundCallWithRequest = _.partial(server.plugins.elasticsearch.callWithRequest, req);
       boundCallWithRequest('search', {
-	index: config.es.alarm_index ? config.es.alarm_index + "*" : "watcher_alarms*",
-	sort : "@timestamp : asc", 
+        index: config.es.alarm_index ? config.es.alarm_index + "*" : "watcher_alarms*",
+        sort: "@timestamp : asc",
         allowNoIndices: false,
-	body: {
-		"size": config.kaae.results ? config.kaae.results : 50,
-   		"query": {
-        		"filtered": {
-        		    "query": {
-        		        "match_all": {}
-    			        },
-    		        "filter": {
-    		            "range": {
-    		                "@timestamp": qrange
-    		            }
-    		        }
-    		    }
-    		}
-	}
-      })
-      .then(
-        function (res) {
-          reply(res); 
-        },
-        function (error) {
-          reply(handleESError(error));
+        body: {
+          "size": config.kaae.results ? config.kaae.results : 50,
+          "query": {
+            "filtered": {
+              "query": {
+                "match_all": {}
+              },
+              "filter": {
+                "range": {
+                  "@timestamp": qrange
+                }
+              }
+            }
+          }
         }
-      );
+      })
+      .then((res) => reply(res))
+      .catch((err) => reply(handleESError(err)));
     }
   });
 
@@ -89,32 +81,24 @@ export default function (server) {
     handler: function (req, reply) {
       const boundCallWithRequest = _.partial(server.plugins.elasticsearch.callWithRequest, req);
       boundCallWithRequest('search', {
-	index: 'watcher',
-	size: config.kaae.results ? config.kaae.results : 50,
+        index: 'watcher',
+        size: config.kaae.results ? config.kaae.results : 50,
         allowNoIndices: false
       })
-      .then(
-        function (res) {
-          reply(res); 
-        },
-        function (error) {
-          reply(handleESError(error));
-        }
-      );
+      .then((res) => reply(res))
+      .catch((err) => reply(handleESError(err)))
     }
   });
-
 
   server.route({
     method: 'GET',
     path: '/api/kaae/delete/alarm/{index}/{type}/{id}',
     handler: function (req, reply) {
       // Check if alarm index and discard everything else
-      if (!req.params.index.substr(0,config.es.alarm_index.length) === config.es.alarm_index) { 
-		server.log(['status', 'err', 'KaaE'], 'Forbidden Delete Request! '+req.params);
-		return;
+      if (!req.params.index.substr(0, config.es.alarm_index.length) === config.es.alarm_index) {
+        server.log(['status', 'err', 'KaaE'], 'Forbidden Delete Request! ' + req.params);
+        return;
       }
-      var client = server.plugins.elasticsearch.client;
       var callWithRequest = server.plugins.elasticsearch.callWithRequest;
 
       var body = {
@@ -123,21 +107,20 @@ export default function (server) {
         id: req.params.id
       };
 
-      callWithRequest(req, 'delete', body).then(function (resp) {
+      callWithRequest(req, 'delete', body)
+      .then((resp) => {
         reply({
           ok: true,
-	  resp: resp
+          resp: resp
         });
-      }).catch(function (resp) {
+      }).catch((resp) => {
         reply({
           ok: false,
           resp: resp
         });
       });
-
-   }
+    }
   });
-
 
   /* ES Functions */
 
@@ -189,47 +172,44 @@ export default function (server) {
     method: 'GET',
     path: '/api/kaae/get/watcher/{id}',
     handler: function (request, reply) {
-      var client = server.plugins.elasticsearch.client;
-
-	server.log(['status', 'info', 'KaaE'], 'Get Watcher with ID: '+request.params.id);
-	client.search({
-	  index: config.es.default_index,
-	  type: config.es.type,
-	  q: request.params.id
-	}).then(function (resp) {
-	    var hits = resp.hits.hits;
-            reply( resp );
-	}, function (err,resp) {
-	    console.trace(err.message);
-            reply( resp );
-	});
-   }
+      const callWithRequest = server.plugins.elasticsearch.callWithRequest;
+      server.log(['status', 'info', 'KaaE'], 'Get Watcher with ID: ' + request.params.id);
+      callWithRequest(request, 'search', {
+        index: config.es.default_index,
+        type: config.es.type,
+        q: request.params.id
+      })
+      .then((resp) => reply(resp))
+      .catch((err, resp) => {
+        server.log(['debug', 'Kaae'], err);
+        reply(resp);
+      });
+    }
   });
 
   server.route({
     method: 'GET',
     path: '/api/kaae/save/watcher/{watcher}',
     handler: function (request, reply) {
-      var client = server.plugins.elasticsearch.client;
-      var watcher = JSON.parse(request.params.watcher)
+      const callWithRequest = server.plugins.elasticsearch.callWithRequest;
+      var watcher = JSON.parse(request.params.watcher);
 
       server.log(['status', 'info', 'KaaE'], 'Saving Watcher with ID: '+watcher._id);
 
-	        var body = {
-	        	index: config.es.default_index,
-	        	type: config.es.type,
-			id: watcher._id,
-	        	body: watcher._source
-	        };
+      var body = {
+        index: config.es.default_index,
+        type: config.es.type,
+        id: watcher._id,
+        body: watcher._source
+      };
 
-	        client.index(body).then(function (resp) {
-        		reply({ ok: true, resp: resp });
-	                   // if (debug) console.log(resp);
-	            }, function (err,resp) {
-        		reply({ ok: false, resp: resp });
-	           	console.trace(err,resp);
-		});
-   }
+      callWithRequest(request, 'index', body)
+      .then(function (resp) {
+        reply({ok: true, resp: resp});
+        // if (debug) console.log(resp);
+      })
+      .catch((err) => reply(handleESError(err)));
+    }
   });
 
 
@@ -237,7 +217,6 @@ export default function (server) {
     method: 'GET',
     path: '/api/kaae/delete/watcher/{id}',
     handler: function (req, reply) {
-      var client = server.plugins.elasticsearch.client;
       var callWithRequest = server.plugins.elasticsearch.callWithRequest;
 
       var body = {
@@ -249,7 +228,7 @@ export default function (server) {
       callWithRequest(req, 'delete', body).then(function (resp) {
         reply({
           ok: true,
-	  resp: resp
+          resp: resp
         });
       }).catch(function (resp) {
         reply({
@@ -288,5 +267,5 @@ export default function (server) {
 
     }
   });
-	
+
 };

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -86,7 +86,7 @@ export default function (server) {
         allowNoIndices: false
       })
       .then((res) => reply(res))
-      .catch((err) => reply(handleESError(err)))
+      .catch((err) => reply(handleESError(err)));
     }
   });
 
@@ -108,17 +108,8 @@ export default function (server) {
       };
 
       callWithRequest(req, 'delete', body)
-      .then((resp) => {
-        reply({
-          ok: true,
-          resp: resp
-        });
-      }).catch((resp) => {
-        reply({
-          ok: false,
-          resp: resp
-        });
-      });
+      .then((resp) => reply({ok: true, resp: resp}))
+      .catch((err) => reply(handleESError(err)));
     }
   });
 
@@ -180,9 +171,9 @@ export default function (server) {
         q: request.params.id
       })
       .then((resp) => reply(resp))
-      .catch((err, resp) => {
+      .catch((err) => {
         server.log(['debug', 'Kaae'], err);
-        reply(resp);
+        reply(err);
       });
     }
   });
@@ -204,14 +195,10 @@ export default function (server) {
       };
 
       callWithRequest(request, 'index', body)
-      .then(function (resp) {
-        reply({ok: true, resp: resp});
-        // if (debug) console.log(resp);
-      })
+      .then((resp) => reply({ok: true, resp: resp}))
       .catch((err) => reply(handleESError(err)));
     }
   });
-
 
   server.route({
     method: 'GET',
@@ -225,21 +212,11 @@ export default function (server) {
         id: req.params.id
       };
 
-      callWithRequest(req, 'delete', body).then(function (resp) {
-        reply({
-          ok: true,
-          resp: resp
-        });
-      }).catch(function (resp) {
-        reply({
-          ok: false,
-          resp: resp
-        });
-      });
-
+      callWithRequest(req, 'delete', body)
+      .then((resp) => reply({ok: true, resp: resp}))
+      .catch((err) => reply(handleESError(err)));
    }
   });
-
 
   server.route({
     method: 'GET',
@@ -258,13 +235,8 @@ export default function (server) {
           min: resp.index._all.fields[config.es.timefield].min_value,
           max: resp.index._all.fields[config.es.timefield].max_value
         });
-      }).catch(function (resp) {
-        reply({
-          ok: false,
-          resp: resp
-        });
-      });
-
+      })
+      .catch((err) => reply(handleESError(err)));
     }
   });
 


### PR DESCRIPTION
This PR improves general error handling and provides integration with the Kibi access control plugin.

- all the API routes use callWithRequest to passthrough auth headers
- authentication errors are notified in the UI
- the backend checks if the kibi_access_control plugin is available and if so gets the Elasticsearch client for alerts from it